### PR TITLE
Initial Structure for Open AI

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/langchain-go.iml
+++ b/.idea/langchain-go.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/langchain-go.iml" filepath="$PROJECT_DIR$/.idea/langchain-go.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # langchain-go
-Go bindings
+Go bindings inspired by [langchain](https://github.com/hwchase17/langchain) and [langchainjs](https://github.com/hwchase17/langchainjs)

--- a/examples/llms/openai/basic_openai_example_test.go
+++ b/examples/llms/openai/basic_openai_example_test.go
@@ -1,0 +1,23 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	openai "github.com/speakeasy-api/langchain-go/llms/openapi"
+	"log"
+	"testing"
+)
+
+// To Execute Set OPENAI_API_KEY
+func TestRun(t *testing.T) {
+	llm, err := openai.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	completion, err := llm.Call(context.Background(), "Question, what kind of bear is best?", []string{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(completion)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/speakeasy-api/langchain-go
+
+go 1.20
+
+require github.com/sashabaranov/go-openai v1.5.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/sashabaranov/go-openai v1.5.8 h1:EfNEmc+Ue+CuRy7iSpNdxfHyiOv2vQsQ2Y0kZRA/z5w=
+github.com/sashabaranov/go-openai v1.5.8/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=

--- a/llms/base.go
+++ b/llms/base.go
@@ -1,0 +1,9 @@
+package llms
+
+import "context"
+
+type LLM interface {
+	Generate(ctx context.Context, prompts []string, stop []string) (*LLMResult, error)
+	Call(ctx context.Context, prompt string, stop []string) (string, error)
+	Name() string
+}

--- a/llms/openapi/openapi.go
+++ b/llms/openapi/openapi.go
@@ -1,0 +1,217 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	goopenai "github.com/sashabaranov/go-openai"
+	"github.com/speakeasy-api/langchain-go/llms"
+)
+
+// Default Params for Open AI model
+const (
+	temperature      float32 = 0.7
+	maxTokens        int     = 256
+	topP             float32 = 1
+	frequencyPenalty float32 = 0
+	presencePenalty  float32 = 0
+	n                int     = 1
+	bestOf           int     = 1
+	modelName        string  = "text-davinci-003"
+	batchSize        int     = 20
+)
+
+type OpenAI struct {
+	apiKey           string
+	temperature      float32
+	maxTokens        int
+	topP             float32
+	frequencyPenalty float32
+	presencePenalty  float32
+	n                int
+	bestOf           int
+	logitBias        map[string]int
+	streaming        bool // Streaming Unsupported Right Now
+	modelName        string
+	modelKwargs      map[string]interface{}
+	batchSize        int
+	stop             []string
+	timeout          *time.Duration
+	client           *goopenai.Client
+}
+
+func New(args ...OpenAIInput) (*OpenAI, error) {
+	if len(args) > 1 {
+		return nil, errors.New("more than one config argument not supported")
+	}
+
+	input := OpenAIInput{}
+	if len(args) > 0 {
+		input = args[0]
+	}
+
+	openai := OpenAI{
+		apiKey:           os.Getenv("OPENAI_API_KEY"),
+		temperature:      temperature,
+		maxTokens:        maxTokens,
+		topP:             topP,
+		frequencyPenalty: frequencyPenalty,
+		presencePenalty:  presencePenalty,
+		n:                n,
+		bestOf:           bestOf,
+		logitBias:        input.logitBias,
+		streaming:        input.streaming,
+		modelName:        modelName,
+		modelKwargs:      input.modelKwargs,
+		batchSize:        batchSize,
+		stop:             input.stop,
+		timeout:          input.timeout,
+	}
+
+	if input.openAIApiKey != nil {
+		openai.apiKey = *input.openAIApiKey
+	}
+
+	if openai.apiKey == "" {
+		return nil, errors.New("OpenAI API key not found")
+	}
+
+	if input.temperature != nil {
+		openai.temperature = *input.temperature
+	}
+
+	if input.maxTokens != nil {
+		openai.maxTokens = *input.maxTokens
+	}
+
+	if input.topP != nil {
+		openai.topP = *input.topP
+	}
+
+	if input.frequencyPenalty != nil {
+		openai.frequencyPenalty = *input.frequencyPenalty
+	}
+
+	if input.presencePenalty != nil {
+		openai.presencePenalty = *input.presencePenalty
+	}
+
+	if input.n != nil {
+		openai.n = *input.n
+	}
+
+	if input.bestOf != nil {
+		openai.bestOf = *input.bestOf
+	}
+
+	if input.modelName != nil {
+		openai.modelName = *input.modelName
+	}
+
+	if input.batchSize != nil {
+		openai.batchSize = *input.batchSize
+	}
+
+	openai.client = goopenai.NewClient(openai.apiKey)
+
+	return &openai, nil
+}
+
+func (openai *OpenAI) Name() string {
+	return "openapi"
+}
+
+func (openai *OpenAI) Call(ctx context.Context, prompt string, stop []string) (string, error) {
+	generations, err := openai.Generate(ctx, []string{prompt}, stop)
+	if err != nil {
+		return "", err
+	}
+
+	return generations.Generations[0][0].Text, nil
+}
+
+func (openai *OpenAI) Generate(ctx context.Context, prompts []string, stop []string) (*llms.LLMResult, error) {
+	subPrompts := llms.BatchSlice[string](prompts, openai.batchSize)
+	maxTokens := openai.maxTokens
+	var completionTokens, promptTokens, totalTokens int
+	var choices []goopenai.CompletionChoice
+
+	if openai.maxTokens == -1 {
+		if len(prompts) != 1 {
+			return nil, errors.New("max_tokens set to -1 not supported for multiple inputs")
+		}
+
+		maxTokens = llms.CalculateMaxTokens(prompts[0], openai.modelName)
+	}
+
+	if len(stop) == 0 {
+		stop = openai.stop
+	}
+
+	for _, prompts := range subPrompts {
+		data, err := openai.completionWithRetry(ctx, prompts, maxTokens, stop)
+		if err != nil {
+			// TODO: Wrap Into Informative Errors
+			return nil, err
+		}
+
+		choices = append(choices, data.Choices...)
+		completionTokens += data.Usage.CompletionTokens
+		promptTokens += data.Usage.PromptTokens
+		totalTokens += data.Usage.TotalTokens
+	}
+	var generations [][]llms.Generation
+	batchedChoices := llms.BatchSlice[goopenai.CompletionChoice](choices, openai.n)
+	for _, batch := range batchedChoices {
+		var generationBatch []llms.Generation
+		for _, choice := range batch {
+			generationBatch = append(generationBatch, llms.Generation{
+				Text: choice.Text,
+				GenerationInfo: map[string]interface{}{
+					"finishReason": choice.FinishReason,
+					"logprobs":     choice.LogProbs,
+				},
+			})
+		}
+		generations = append(generations, generationBatch)
+	}
+
+	return &llms.LLMResult{
+		Generations: generations,
+		LLMOutput: map[string]interface{}{
+			"completionTokens": completionTokens,
+			"promptTokens":     promptTokens,
+			"totalTokens":      totalTokens,
+		},
+	}, nil
+}
+
+func (openai *OpenAI) completionWithRetry(ctx context.Context, prompts []string, maxTokens int, stop []string) (*goopenai.CompletionResponse, error) {
+	request := goopenai.CompletionRequest{
+		Model:            openai.modelName,
+		Prompt:           prompts[0], // TODO: Implement Support for Batching on Next Release
+		MaxTokens:        maxTokens,
+		Temperature:      openai.temperature,
+		TopP:             openai.topP,
+		N:                openai.n,
+		BestOf:           openai.bestOf,
+		LogitBias:        openai.logitBias,
+		PresencePenalty:  openai.presencePenalty,
+		FrequencyPenalty: openai.frequencyPenalty,
+		Stop:             stop,
+	}
+
+	if openai.timeout != nil {
+		ctx, _ = context.WithTimeout(ctx, *openai.timeout)
+	}
+
+	// TODO: Implement Retries
+	resp, err := openai.client.CreateCompletion(
+		ctx,
+		request,
+	)
+
+	return &resp, err
+}

--- a/llms/openapi/types.go
+++ b/llms/openapi/types.go
@@ -1,0 +1,41 @@
+package openai
+
+import "time"
+
+type OpenAIInput struct {
+	// Model name to use
+	modelName *string // TODO: Make into Enum
+	// Holds any additional parameters that are valid to pass to https://platform.openai.com/docs/api-reference/completions/create
+	modelKwargs map[string]interface{}
+	// Batch size to use when passing multiple documents to generate
+	batchSize *int
+	// List of stop words to use when generating
+	stop []string
+	// Timeout to use when making requests to OpenAI
+	timeout *time.Duration
+	// OpenAI API Key
+	openAIApiKey *string
+	ModelParams
+}
+
+type ModelParams struct {
+	// Sampling temperature to use
+	temperature *float32
+	// Maximum number of tokens to generate in the completion. -1 returns as many
+	// tokens as possible given the prompt and the model's maximum context size.
+	maxTokens *int
+	// Total probability mass of tokens to consider at each step
+	topP *float32
+	// Penalizes repeated tokens according to frequency
+	frequencyPenalty *float32
+	// Penalizes repeated tokens
+	presencePenalty *float32
+	// Number of completions to generate for each prompt
+	n *int
+	// Generates `bestOf` completions server side and returns the "best"
+	bestOf *int
+	// Dictionary used to adjust the probability of specific tokens being generated
+	logitBias map[string]int
+	// Whether to stream the results or not. Enabling disables tokenUsage reporting
+	streaming bool
+}

--- a/llms/types.go
+++ b/llms/types.go
@@ -1,0 +1,18 @@
+package llms
+
+type LLMResult struct {
+	Generations [][]Generation
+	LLMOutput   map[string]interface{}
+}
+
+type Generation struct {
+	Text           string
+	GenerationInfo map[string]interface{}
+}
+
+type BaseLLMParams struct {
+	// TODO: Implement when relevant embedded cache and streaming implemented
+	cache           interface{}
+	concurrency     interface{}
+	callbackManager interface{}
+}

--- a/llms/utils.go
+++ b/llms/utils.go
@@ -1,0 +1,20 @@
+package llms
+
+func BatchSlice[T any](slice []T, batchSize int) [][]T {
+	var chunks [][]T
+	for i := 0; i < len(slice); i += batchSize {
+		end := i + batchSize
+		if end > len(slice) {
+			end = len(slice)
+		}
+
+		chunks = append(chunks, slice[i:end])
+	}
+
+	return chunks
+}
+
+// TODO: Implement Max Token Inference
+func CalculateMaxTokens(prompt string, modelName string) int {
+	return 1
+}


### PR DESCRIPTION
## Description

- Creates initial structure for LLM interface and OpenAI bindings
- This was most directly modeled after https://github.com/hwchase17/langchainjs/blob/main/langchain/src/llms/openai.ts
- To test `cd examples/llms/openai && go test -v .`

## Notable Decisions
- For the OpenAI client we are using https://github.com/sashabaranov/go-openai. Langchain and LangchainJS themselves use the bindings that openai produces for [python and javascript](https://platform.openai.com/docs/api-reference). OpenAI recommends this go library in its [community lead projects](https://platform.openai.com/docs/libraries/go), it seems to have pretty reasonable engagement. I'm definitely open to building our own client, openai APIs aren't very complicated. I think we can move to that later on if this library doesn't support our needs, let me know your thoughts here.

## Next Steps

- Code Polishing
- Testing
- Batched Requests
- Retries
- OpenAI Chat Implemented (langchain treats it separate)

## Possibly After That (More LLMS?)
- Hugging Face?
- Cohere?
- Streaming
- Embedded Caching



