### PR TITLE
add support for openaichat

### DIFF
--- a/examples/llms/openai/openai_test.go
+++ b/examples/llms/openai/openai_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	openai "github.com/speakeasy-api/langchain-go/llms/openai"
 	"log"
-	"net"
 	"testing"
 )
 
@@ -18,9 +17,7 @@ func TestBasicCompletion(t *testing.T) {
 	}
 	completion, err := llm.Call(context.Background(), "Question, what kind of bear is best?", []string{})
 	if err != nil {
-		if err, ok := err.(net.Error); ok && err.Timeout() {
-			log.Fatal(err)
-		}
+		log.Fatal(err)
 	}
 
 	fmt.Println(completion)

--- a/examples/llms/openaichat/openai_chat_test.go
+++ b/examples/llms/openaichat/openai_chat_test.go
@@ -1,0 +1,44 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"github.com/speakeasy-api/langchain-go/llms/openaichat"
+	"log"
+	"testing"
+)
+
+// To Execute EXPORT OPENAI_API_KEY=...
+
+func TestFirstMessageChat(t *testing.T) {
+	llm, err := openaichat.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	completion, err := llm.Call(context.Background(), "Hi, how are you?", []string{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(completion)
+}
+
+func TestMultiMessageChat(t *testing.T) {
+	llm, err := openaichat.New(openaichat.OpenAIChatInput{
+		PrefixMessages: []openaichat.ChatMessage{
+			{
+				Content: "Mount Everest is the tallest mountain in the world.",
+				Role:    openaichat.ChatMessageRoleEnumAssistant,
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	completion, err := llm.Call(context.Background(), "How tall is it?", []string{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(completion)
+}

--- a/llms/internal/openaishared/errors.go
+++ b/llms/internal/openaishared/errors.go
@@ -1,0 +1,34 @@
+package openaishared
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type OpenAIError struct {
+	error
+
+	statusCode int
+	status     string
+}
+
+func (e *OpenAIError) Error() string {
+	return fmt.Sprintf("error in call to openai with status %s", e.status)
+}
+
+func (e *OpenAIError) GetStatusCode() int {
+	return e.statusCode
+}
+
+func (e *OpenAIError) IsRetryable() bool {
+	return e.statusCode == http.StatusTooManyRequests || e.statusCode == http.StatusInternalServerError
+}
+
+func CreateOpenAIError(statusCode int, status string) *OpenAIError {
+	err := OpenAIError{
+		statusCode: statusCode,
+		status:     status,
+	}
+
+	return &err
+}

--- a/llms/internal/openaishared/http_client.go
+++ b/llms/internal/openaishared/http_client.go
@@ -1,0 +1,19 @@
+package openaishared
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type authorizeTransport struct {
+	ApiKey string
+}
+
+func (t *authorizeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.ApiKey))
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func OpenAIAuthenticatedClient(apiKey string) http.Client {
+	return http.Client{Transport: &authorizeTransport{ApiKey: apiKey}}
+}

--- a/llms/openaichat/openai_chat.go
+++ b/llms/openaichat/openai_chat.go
@@ -1,0 +1,240 @@
+package openaichat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	langchain "github.com/speakeasy-api/langchain-go/llms/openai"
+	gpt "github.com/speakeasy-sdks/openai-go-sdk"
+	"github.com/speakeasy-sdks/openai-go-sdk/pkg/models/shared"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/speakeasy-api/langchain-go/llms"
+)
+
+// Default Params for Open AI model
+const (
+	temperature      float64 = 1
+	topP             float64 = 1
+	frequencyPenalty float64 = 0
+	presencePenalty  float64 = 0
+	n                int64   = 1
+	modelName        string  = "gpt-3.5-turbo"
+	maxRetries       int     = 3
+)
+
+type OpenAIChat struct {
+	temperature      float64
+	maxTokens        int64
+	topP             float64
+	frequencyPenalty float64
+	presencePenalty  float64
+	n                int64
+	logitBias        map[string]interface{}
+	streaming        bool // Streaming Unsupported Right Now
+	modelName        string
+	modelKwargs      map[string]interface{}
+	maxRetries       int
+	stop             []string
+	prefixMessages   []ChatMessage
+	timeout          *time.Duration
+	client           *gpt.Gpt
+}
+
+func New(args ...OpenAIChatInput) (*OpenAIChat, error) {
+	if len(args) > 1 {
+		return nil, errors.New("more than one config argument not supported")
+	}
+
+	input := OpenAIChatInput{}
+	if len(args) > 0 {
+		input = args[0]
+	}
+
+	openai := OpenAIChat{
+		temperature:      temperature,
+		topP:             topP,
+		frequencyPenalty: frequencyPenalty,
+		presencePenalty:  presencePenalty,
+		n:                n,
+		logitBias:        input.LogitBias,
+		streaming:        input.Streaming,
+		modelName:        modelName,
+		modelKwargs:      input.ModelKwargs,
+		stop:             input.Stop,
+		timeout:          input.Timeout,
+		maxRetries:       maxRetries,
+		prefixMessages:   input.PrefixMessages,
+	}
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+
+	if input.OpenAIApiKey != nil {
+		apiKey = *input.OpenAIApiKey
+	}
+
+	if apiKey == "" {
+		return nil, errors.New("OpenAI API key not found")
+	}
+
+	if input.Temperature != nil {
+		openai.temperature = *input.Temperature
+	}
+
+	if input.MaxTokens != nil {
+		openai.maxTokens = *input.MaxTokens
+	}
+
+	if input.TopP != nil {
+		openai.topP = *input.TopP
+	}
+
+	if input.FrequencyPenalty != nil {
+		openai.frequencyPenalty = *input.FrequencyPenalty
+	}
+
+	if input.PresencePenalty != nil {
+		openai.presencePenalty = *input.PresencePenalty
+	}
+
+	if input.N != nil {
+		openai.n = *input.N
+	}
+
+	if input.ModelName != nil {
+		openai.modelName = *input.ModelName
+	}
+
+	if input.MaxRetries != nil {
+		openai.maxRetries = *input.MaxRetries
+	}
+
+	httpClient := http.Client{Transport: &langchain.AuthorizeTransport{ApiKey: apiKey}}
+
+	if openai.timeout != nil {
+		httpClient.Timeout = *openai.timeout
+	}
+
+	client := gpt.New(gpt.WithClient(&httpClient))
+	openai.client = client
+
+	return &openai, nil
+}
+
+func (openai *OpenAIChat) Name() string {
+	return "openai-chat"
+}
+
+func (openai *OpenAIChat) Call(ctx context.Context, prompt string, stop []string) (string, error) {
+	if len(stop) == 0 {
+		stop = openai.stop
+	}
+
+	data, err := openai.completionWithRetry(ctx, prompt, openai.maxTokens, stop)
+	if err != nil {
+		return "", err
+	}
+
+	message := ""
+	if len(data.Choices) > 0 && data.Choices[0].Message != nil {
+		message = data.Choices[0].Message.Content
+	}
+
+	return message, nil
+}
+
+func (openai *OpenAIChat) Generate(ctx context.Context, prompts []string, stop []string) (*llms.LLMResult, error) {
+	// Not Implemented for OpenAIChat
+	return nil, nil
+}
+
+func (openai *OpenAIChat) completionWithRetry(ctx context.Context, prompt string, maxTokens int64, stop []string) (*shared.CreateChatCompletionResponse, error) {
+	request := shared.CreateChatCompletionRequest{
+		Model:            openai.modelName,
+		Messages:         formatMessages(openai.prefixMessages, prompt),
+		Temperature:      &openai.temperature,
+		TopP:             &openai.topP,
+		N:                &openai.n,
+		LogitBias:        openai.logitBias,
+		PresencePenalty:  &openai.presencePenalty,
+		FrequencyPenalty: &openai.frequencyPenalty,
+	}
+	if openai.maxTokens != 0 {
+		request.MaxTokens = &openai.maxTokens
+	}
+
+	if len(stop) != 0 {
+		stopRequest := shared.CreateCreateChatCompletionRequestStopArrayOfstr(stop)
+		request.Stop = &stopRequest
+	}
+
+	var finalResult *shared.CreateChatCompletionResponse
+	var finalErr error
+
+	// wait 2^x second between each retry starting with
+	// max 10 seconds
+	for i := 0; i < openai.maxRetries; i++ {
+		lastTry := i == openai.maxRetries-1
+		sleep := int(math.Min(math.Pow(2, float64(i)), float64(10)))
+		res, err := openai.client.OpenAI.CreateChatCompletion(ctx, request)
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) {
+				// retry on client timeout
+				if netErr.Timeout() && !lastTry {
+					time.Sleep(time.Duration(sleep) * time.Second)
+					continue
+				}
+			}
+
+			return nil, err
+		}
+
+		if res.StatusCode == http.StatusOK {
+			finalResult = res.CreateChatCompletionResponse
+			break
+		} else {
+			if lastTry || !langchain.StatusCodeIsRetryable(res.StatusCode) {
+				// TODO: Improve Error Parsing
+				finalErr = errors.New(fmt.Sprintf("error in call to openai with status %s", res.RawResponse.Status))
+				break
+			}
+		}
+
+		time.Sleep(time.Duration(sleep) * time.Second)
+	}
+
+	return finalResult, finalErr
+}
+
+func formatMessages(previous []ChatMessage, message string) []shared.ChatCompletionRequestMessage {
+	var result []shared.ChatCompletionRequestMessage
+	for _, message := range previous {
+		result = append(result, shared.ChatCompletionRequestMessage{
+			Content: message.Content,
+			Role:    convertRoleEnum(message.Role),
+		})
+	}
+	result = append(result, shared.ChatCompletionRequestMessage{
+		Content: message,
+		Role:    shared.ChatCompletionRequestMessageRoleEnumUser,
+	})
+	return result
+}
+
+func convertRoleEnum(enum ChatMessageRoleEnum) shared.ChatCompletionRequestMessageRoleEnum {
+	switch enum {
+	case ChatMessageRoleEnumSystem:
+		return shared.ChatCompletionRequestMessageRoleEnumSystem
+	case ChatMessageRoleEnumUser:
+		return shared.ChatCompletionRequestMessageRoleEnumUser
+	case ChatMessageRoleEnumAssistant:
+		return shared.ChatCompletionRequestMessageRoleEnumAssistant
+	default:
+		return ""
+	}
+}

--- a/llms/openaichat/openai_chat.go
+++ b/llms/openaichat/openai_chat.go
@@ -134,7 +134,7 @@ func (openai *OpenAIChat) Call(ctx context.Context, prompt string, stop []string
 		stop = openai.stop
 	}
 
-	data, err := openai.completionWithRetry(ctx, prompt, openai.maxTokens, stop)
+	data, err := openai.chatCompletionWithRetry(ctx, prompt, openai.maxTokens, stop)
 	if err != nil {
 		return "", err
 	}
@@ -152,7 +152,7 @@ func (openai *OpenAIChat) Generate(ctx context.Context, prompts []string, stop [
 	return nil, nil
 }
 
-func (openai *OpenAIChat) completionWithRetry(ctx context.Context, prompt string, maxTokens int64, stop []string) (*shared.CreateChatCompletionResponse, error) {
+func (openai *OpenAIChat) chatCompletionWithRetry(ctx context.Context, prompt string, maxTokens int64, stop []string) (*shared.CreateChatCompletionResponse, error) {
 	request := shared.CreateChatCompletionRequest{
 		Model:            openai.modelName,
 		Messages:         formatMessages(openai.prefixMessages, prompt),

--- a/llms/openaichat/types.go
+++ b/llms/openaichat/types.go
@@ -1,0 +1,25 @@
+package openaichat
+
+import (
+	"github.com/speakeasy-api/langchain-go/llms/openai"
+)
+
+type OpenAIChatInput struct {
+	// ChatGPT messages to pass as a prefix to the prompt
+	PrefixMessages []ChatMessage
+
+	openai.OpenAIInput
+}
+
+type ChatMessage struct {
+	Content string
+	Role    ChatMessageRoleEnum
+}
+
+type ChatMessageRoleEnum string
+
+const (
+	ChatMessageRoleEnumSystem    ChatMessageRoleEnum = "system"
+	ChatMessageRoleEnumUser      ChatMessageRoleEnum = "user"
+	ChatMessageRoleEnumAssistant ChatMessageRoleEnum = "assistant"
+)


### PR DESCRIPTION
## Description

Builds in support for openaichat which is a separate sub module in [langchain](https://github.com/hwchase17/langchainjs/blob/main/langchain/src/llms/openai-chat.ts)

## Next Steps

- Test integration in speakeasy CLI
- More langchain-go cleanup (testing, maxTokenInference, etc.)
- Maybe add some more models (hugging face, cohere)